### PR TITLE
Updated to be in line with how ember-cli-deploy handles context data

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,14 +15,14 @@ module.exports = {
     return {
       name: options.name,
 
-      build: function(context) {
-        var config = context.config.get(this.name);
-        var data   = context.data;
+      didBuild: function(context) {
+        var deployment = context.deployment;
+        var config     = deployment.config[this.name] || {};
 
         var Tag = tagFor(config.type);
-        var tag = new Tag(data);
+        var tag = new Tag(context);
 
-        context.data.tag = tag.generate();
+        return { tag: tag.generate() };
       }
     };
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "before": "ember-cli-deploy-json-config",
-    "after": "ember-cli-deploy-build"
+    "before": "ember-cli-deploy-json-config"
   }
 }

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var assert = require('ember-cli/tests/helpers/assert');
+
+describe('the index', function() {
+  var subject;
+
+  before(function() {
+    subject = require('../../index');
+  });
+
+  it('has a name', function() {
+    var result = subject.createDeployPlugin({
+      name: 'test-plugin'
+    });
+
+    assert.equal('test-plugin', result.name);
+  });
+
+  it('implements the correct hooks', function() {
+    var result = subject.createDeployPlugin({
+      name: 'test-plugin'
+    });
+
+    assert.equal(typeof result.didBuild, 'function');
+  });
+
+
+  describe('didBuild hook', function() {
+    it ('returns the tag data', function() {
+      var plugin = subject.createDeployPlugin({
+        name: 'test-plugin'
+      });
+
+      var context = {
+        deployment: {
+          config: {}
+        },
+        indexPath: process.cwd() + '/tests/fixtures/index.html'
+      };
+
+      var result = plugin.didBuild.call(plugin, context);
+
+      assert.equal(result.tag, 'ae1569f72495012cd5e8588e0f2f5d49');
+    });
+  });
+});
+


### PR DESCRIPTION
This PR does the following:
- Removes the need for the "after" hook in the `pacakge.json`.  This is because ember-cli-deploy now supports the `didBuild` hook.
- Accesses the deployment context via `context.deployment`
- Assumes config is now the real config and not the Configuration object
- returns the data that is to be merged into the `context`
