### PR TITLE
Remove dependency on index path

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,10 @@ module.exports = {
         var type       = config.type;
 
         var Tag = tags[type];
-        var tag = new Tag(context);
+        var tag = new Tag({
+          config: config,
+          context: context
+        });
 
         return _beginMessage(ui, type)
           .then(function() {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 /* jshint node: true */
 'use strict';
 
+var chalk = require('chalk');
+var blue  = chalk.blue;
+
+var validateConfig = require('./lib/utilities/validate-config');
+
 module.exports = {
   name: 'ember-cli-deploy-tag',
 
@@ -14,6 +19,18 @@ module.exports = {
 
     return {
       name: options.name,
+
+      willDeploy: function(context) {
+        var deployment = context.deployment;
+        var ui         = deployment.ui;
+        var config     = deployment.config[this.name] || {};
+
+        return validateConfig(ui, config)
+          .then(function() {
+            ui.write(blue('|    '));
+            ui.writeLine(blue('- config ok'));
+          });
+      },
 
       didBuild: function(context) {
         var deployment = context.deployment;

--- a/lib/tags/index-hash.js
+++ b/lib/tags/index-hash.js
@@ -1,21 +1,34 @@
+var CoreObject  = require('core-object');
 var fs          = require('fs');
 var Fingerprint = require('broccoli-asset-rev/lib/fingerprint');
 
-function IndexHashTag(options) {
-  this.options = options || {};
-}
+module.exports = CoreObject.extend({
+  init: function(options) {
+    this._context = options.context || {};
+    this._config = options.config || {};
+  },
 
-IndexHashTag.prototype.generate = function() {
-  var indexPath = this.options.indexPath;
+  generate: function() {
+    var filePattern = this._config.filePattern;
+    var distFiles   = this._context.distFiles;
+    var index       = distFiles.indexOf(filePattern);
+    var indexPath;
+    var contents;
+    var fingerprint;
 
-  if (!fs.existsSync(indexPath)) {
-    return '';
+    if (index === -1) {
+      return '';
+    }
+
+    indexPath = distFiles[index];
+
+    if (!fs.existsSync(indexPath)) {
+      return '';
+    }
+
+    contents    = fs.readFileSync(indexPath);
+    fingerprint = new Fingerprint();
+
+    return fingerprint.hashFn(contents);
   }
-
-  var contents    = fs.readFileSync(indexPath);
-  var fingerprint = new Fingerprint();
-
-  return fingerprint.hashFn(contents);
-};
-
-module.exports = IndexHashTag;
+});

--- a/lib/utilities/validate-config.js
+++ b/lib/utilities/validate-config.js
@@ -10,7 +10,7 @@ module.exports = function(ui, config) {
 
   var defaultConfig = {
     type: 'index-hash',
-    filePattern: 'index.html'
+    filePattern: 'dist/index.html'
   };
 
   ['type', 'filePattern'].forEach(function(prop) {

--- a/lib/utilities/validate-config.js
+++ b/lib/utilities/validate-config.js
@@ -9,15 +9,18 @@ module.exports = function(ui, config) {
   ui.writeLine(blue('- validating config'));
 
   var defaultConfig = {
+    type: 'index-hash',
     filePattern: 'index.html'
   };
 
-  if (!config.filePattern) {
-    var value = defaultConfig.filePattern;
-    config.filePattern = value;
-    ui.write(blue('|    '));
-    ui.writeLine(yellow('- Missing config: `filePattern`, using default: `' + value + '`'));
-  }
+  ['type', 'filePattern'].forEach(function(prop) {
+    if (!config[prop]) {
+      var value = defaultConfig[prop];
+      config[prop] = value;
+      ui.write(blue('|    '));
+      ui.writeLine(yellow('- Missing config: `' + prop + '`, using default: `' + value + '`'));
+    }
+  });
 
   return Promise.resolve();
 }

--- a/lib/utilities/validate-config.js
+++ b/lib/utilities/validate-config.js
@@ -1,0 +1,23 @@
+var Promise = require('ember-cli/lib/ext/promise');
+
+var chalk  = require('chalk');
+var yellow = chalk.yellow;
+var blue   = chalk.blue;
+
+module.exports = function(ui, config) {
+  ui.write(blue('|    '));
+  ui.writeLine(blue('- validating config'));
+
+  var defaultConfig = {
+    filePattern: 'index.html'
+  };
+
+  if (!config.filePattern) {
+    var value = defaultConfig.filePattern;
+    config.filePattern = value;
+    ui.write(blue('|    '));
+    ui.writeLine(yellow('- Missing config: `filePattern`, using default: `' + value + '`'));
+  }
+
+  return Promise.resolve();
+}

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
+    "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "before": "ember-cli-deploy-json-config"
+    "after": "ember-cli-deploy-json-config"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
+    "chalk": "^1.0.0",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -25,6 +25,29 @@ describe('the index', function() {
     assert.equal(typeof result.didBuild, 'function');
   });
 
+  describe('willDeploy hook', function() {
+    it('resolves if config is ok', function() {
+      var plugin = subject.createDeployPlugin({
+        name: 'tag'
+      });
+
+      var context = {
+        deployment: {
+          ui: {
+            write: function() {},
+            writeLine: function() {}
+          },
+          config: {
+            tag: {
+              filePattern: 'eeee'
+            }
+          }
+        }
+      };
+
+      return assert.isFulfilled(plugin.willDeploy.call(plugin, context))
+    });
+  });
 
   describe('didBuild hook', function() {
     it ('returns the tag data', function() {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -64,11 +64,12 @@ describe('the index', function() {
           },
           config: {
             tag: {
-              type: 'index-hash'
-            }
+              type: 'index-hash',
+              filePattern: process.cwd() + '/tests/fixtures/index.html'
+            },
           }
         },
-        indexPath: process.cwd() + '/tests/fixtures/index.html'
+        distFiles: [process.cwd() + '/tests/fixtures/index.html']
       };
 
       return assert.isFulfilled(plugin.didBuild.call(plugin, context))

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -39,6 +39,7 @@ describe('the index', function() {
           },
           config: {
             tag: {
+              type: 'index-hash',
               filePattern: 'eeee'
             }
           }
@@ -52,19 +53,28 @@ describe('the index', function() {
   describe('didBuild hook', function() {
     it ('returns the tag data', function() {
       var plugin = subject.createDeployPlugin({
-        name: 'test-plugin'
+        name: 'tag'
       });
 
       var context = {
         deployment: {
-          config: {}
+          ui: {
+            write: function() {},
+            writeLine: function() {}
+          },
+          config: {
+            tag: {
+              type: 'index-hash'
+            }
+          }
         },
         indexPath: process.cwd() + '/tests/fixtures/index.html'
       };
 
-      var result = plugin.didBuild.call(plugin, context);
-
-      assert.equal(result.tag, 'ae1569f72495012cd5e8588e0f2f5d49');
+      return assert.isFulfilled(plugin.didBuild.call(plugin, context))
+        .then(function(result) {
+          assert.equal(result.tag, 'ae1569f72495012cd5e8588e0f2f5d49');
+        });
     });
   });
 });

--- a/tests/unit/lib/tags/index-hash-nodetest.js
+++ b/tests/unit/lib/tags/index-hash-nodetest.js
@@ -12,7 +12,12 @@ describe('the index-hash tag', function() {
   describe('#generate', function() {
     it ('generates a hash of the supplied index file', function() {
       var subject = new Tag({
-        indexPath: process.cwd() + '/tests/fixtures/index.html'
+        context: {
+          distFiles: [process.cwd() + '/tests/fixtures/index.html'],
+        },
+        config: {
+          filePattern: process.cwd() + '/tests/fixtures/index.html'
+        }
       });
 
       var hash = subject.generate();
@@ -22,7 +27,12 @@ describe('the index-hash tag', function() {
 
     it('returns an empty string when the file doesn\'t exist', function() {
       var subject = new Tag({
-        indexPath: 'non-existent-file.xml'
+        context: {
+          distFiles: [process.cwd() + '/tests/fixtures/index.html'],
+        },
+        config: {
+          filePattern: 'some-file-that-does-not-exist'
+        }
       });
 
       var hash = subject.generate();

--- a/tests/unit/lib/utilities/validate-config-nodetest.js
+++ b/tests/unit/lib/utilities/validate-config-nodetest.js
@@ -1,0 +1,57 @@
+var assert = require('ember-cli/tests/helpers/assert');
+
+describe('validate-config', function() {
+  var subject;
+  var config;
+  var mockUi;
+
+  before(function() {
+    subject = require('../../../../lib/utilities/validate-config');
+  });
+
+  beforeEach(function() {
+    config = {
+      filePattern: 'eeee'
+    };
+
+    mockUi = {
+      messages: [],
+      write: function() { },
+      writeLine: function(message) {
+        this.messages.push(message);
+      }
+    };
+  });
+
+  it('warns about missing optional config', function() {
+    delete config.filePattern;
+
+    return assert.isFulfilled(subject(mockUi, config))
+      .then(function() {
+        var messages = mockUi.messages.reduce(function(previous, current) {
+          if (/- Missing config:\s.*, using default:\s/.test(current)) {
+            previous.push(current);
+          }
+
+          return previous;
+        }, []);
+
+        assert.equal(messages.length, 1);
+      });
+  });
+
+  it('adds default config to the config object', function() {
+    delete config.filePattern;
+
+    assert.isUndefined(config.filePattern);
+
+    return assert.isFulfilled(subject(mockUi, config))
+      .then(function() {
+        assert.isDefined(config.filePattern);
+      });
+  });
+
+  it('resolves if config is ok', function() {
+    return assert.isFulfilled(subject(mockUi, config));
+  })
+});

--- a/tests/unit/lib/utilities/validate-config-nodetest.js
+++ b/tests/unit/lib/utilities/validate-config-nodetest.js
@@ -11,6 +11,7 @@ describe('validate-config', function() {
 
   beforeEach(function() {
     config = {
+      type: 'aaaa',
       filePattern: 'eeee'
     };
 
@@ -24,6 +25,7 @@ describe('validate-config', function() {
   });
 
   it('warns about missing optional config', function() {
+    delete config.type;
     delete config.filePattern;
 
     return assert.isFulfilled(subject(mockUi, config))
@@ -36,17 +38,20 @@ describe('validate-config', function() {
           return previous;
         }, []);
 
-        assert.equal(messages.length, 1);
+        assert.equal(messages.length, 2);
       });
   });
 
   it('adds default config to the config object', function() {
+    delete config.type;
     delete config.filePattern;
 
+    assert.isUndefined(config.type);
     assert.isUndefined(config.filePattern);
 
     return assert.isFulfilled(subject(mockUi, config))
       .then(function() {
+        assert.isDefined(config.type);
         assert.isDefined(config.filePattern);
       });
   });


### PR DESCRIPTION
This PR does the following:
- Validates config in the `willDeploy` hook
- Uses a `filePattern` to determine which file to use as the index file
- Use the user defined config over the context attrs
