### PR TITLE
Rename index-hash to file-hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
       willDeploy: function(context) {
         var deployment = context.deployment;
         var ui         = deployment.ui;
-        var config     = deployment.config[this.name] || {};
+        var config     = deployment.config[this.name] = deployment.config[this.name] || {};
 
         return validateConfig(ui, config)
           .then(function() {

--- a/lib/tags/file-hash.js
+++ b/lib/tags/file-hash.js
@@ -3,6 +3,7 @@ var fs          = require('fs');
 var path        = require('path');
 var minimatch   = require('minimatch');
 var Fingerprint = require('broccoli-asset-rev/lib/fingerprint');
+var Promise     = require('ember-cli/lib/ext/promise');
 
 var denodeify   = require('rsvp').denodeify;
 var readFile    = denodeify(fs.readFile);
@@ -22,7 +23,7 @@ module.exports = CoreObject.extend({
     var filePaths = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
 
     if (!filePaths.length) {
-      return Promise.reject('`' + filePattern + '` does not exist in distDir');
+      return Promise.reject('`' + filePattern + '` does not exist in distDir `' + distDir + '`');
     }
 
     var filePath = path.join(distDir, filePaths[0]);

--- a/lib/tags/index.js
+++ b/lib/tags/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  "index-hash": require('./index-hash')
+  "file-hash": require('./file-hash')
 };

--- a/lib/utilities/validate-config.js
+++ b/lib/utilities/validate-config.js
@@ -9,7 +9,7 @@ module.exports = function(ui, config) {
   ui.writeLine(blue('- validating config'));
 
   var defaultConfig = {
-    type: 'index-hash',
+    type: 'file-hash',
     filePattern: 'index.html'
   };
 

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -39,7 +39,7 @@ describe('the index', function() {
           },
           config: {
             tag: {
-              type: 'index-hash',
+              type: 'file-hash',
               filePattern: 'eeee'
             }
           }
@@ -57,7 +57,7 @@ describe('the index', function() {
       });
 
       var context = {
-        distDir: process.cwd() + '/tests/fixtures',
+        distDir: 'tests/fixtures',
         distFiles: ['index.html'],
         deployment: {
           ui: {
@@ -66,7 +66,7 @@ describe('the index', function() {
           },
           config: {
             tag: {
-              type: 'index-hash',
+              type: 'file-hash',
               filePattern: 'index.html'
             },
           }

--- a/tests/unit/lib/tags/file-hash-nodetest.js
+++ b/tests/unit/lib/tags/file-hash-nodetest.js
@@ -2,18 +2,18 @@
 
 var assert = require('ember-cli/tests/helpers/assert');
 
-describe('the index-hash tag', function() {
+describe('the file-hash tag', function() {
   var Tag;
 
   before(function() {
-    Tag = require('../../../../lib/tags/index-hash');
+    Tag = require('../../../../lib/tags/file-hash');
   });
 
   describe('#generate', function() {
     it ('generates a hash of the supplied index file', function() {
       var subject = new Tag({
         context: {
-          distDir: process.cwd() + '/tests/fixtures',
+          distDir: 'tests/fixtures',
           distFiles: ['index.html'],
         },
         config: {
@@ -30,7 +30,7 @@ describe('the index-hash tag', function() {
     it('rejects when the filePattern doesn\'t exist in distFiles', function() {
       var subject = new Tag({
         context: {
-          distDir: process.cwd() + '/tests/fixtures',
+          distDir: 'tests/fixtures',
           distFiles: ['index.html']
         },
         config: {
@@ -40,14 +40,14 @@ describe('the index-hash tag', function() {
 
       return assert.isRejected(subject.generate())
         .then(function(error) {
-          assert.equal(error, '`some-file-that-does-not-exist` does not exist in distDir');
+          assert.equal(error, '`some-file-that-does-not-exist` does not exist in distDir `tests/fixtures`');
         });
     });
 
     it('rejects when the file doesn\'t exist', function() {
       var subject = new Tag({
         context: {
-          distDir: process.cwd() + '/tests/fixtures',
+          distDir: 'tests/fixtures',
           distFiles: ['index.xxx']
         },
         config: {


### PR DESCRIPTION
The index-hash tag strategy can be used for any file (via filePattern), so let's call it file-hash.
