### PR TITLE
Add git-commit data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For detailed information on how configuration of plugins works, please refer to 
 The type of [Data Generator](#data-generators) to be used.
 
 *Default:* `'file-hash'`
-*Alternatives:* `'git-tag-commit'`, `'version-commit'`
+*Alternatives:* `'git-tag-commit'`, `'git-commit'`, `'version-commit'`
 
 ## Data Generators
 
@@ -106,6 +106,22 @@ Constructs a revision key based on the most recent git tag and the currently che
 The unique identifier of this build based on the git tag, followed by a `+` symbol, followed by the first 8 characters of the current commit hash.
 
 For example, if your most recent git tag is `v2.0.3`, and the current commit is `0993043d49f9e0[...]`, this generator will return a revision of `v2.0.3+0993043d`.
+
+##### timestamp
+
+The timestamp of the current deploy
+
+### Git Commit generator
+
+Constructs a revision key based on the most recent git commit.
+
+#### Data fields returned
+
+##### revisionKey
+
+The unique identifier of this build based on the first 7 characters of the current commit hash.
+
+For example, if the current commit is `0993043d49f9e0[...]`, this generator will return a revision of `0993043`.
 
 ##### timestamp
 

--- a/lib/data-generators/git-commit.js
+++ b/lib/data-generators/git-commit.js
@@ -1,0 +1,25 @@
+var CoreObject  = require('core-object');
+var gitRepoInfo = require('git-repo-info');
+var Promise     = require('ember-cli/lib/ext/promise');
+
+module.exports = CoreObject.extend({
+  generate: function() {
+    var path = gitRepoInfo._findRepo();
+
+    if (path === null) {
+      return Promise.reject('Could not find git repository');
+    }
+
+    var info = gitRepoInfo(path);
+    var sha = info.sha.slice(0, 7);
+
+    if (!sha) {
+      return Promise.reject('Could not build revision with commit hash `' + sha + '`');
+    }
+
+    return Promise.resolve({
+      revisionKey: sha,
+      timestamp: new Date().toISOString()
+    });
+  }
+});

--- a/lib/data-generators/index.js
+++ b/lib/data-generators/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   "file-hash": require('./file-hash'),
   "git-tag-commit": require('./git-tag-commit'),
+  "git-commit": require('./git-commit'),
   "version-commit": require('./version-commit')
 };

--- a/tests/unit/lib/data-generators/git-commit-nodetest.js
+++ b/tests/unit/lib/data-generators/git-commit-nodetest.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var assert = require('ember-cli/tests/helpers/assert');
+var gitRepoInfo = require('git-repo-info');
+
+describe('the git-commit data generator', function() {
+  var DataGenerator;
+  var cwd;
+
+  before(function() {
+    DataGenerator = require('../../../../lib/data-generators/git-commit');
+    gitRepoInfo._changeGitDir('dotgit');
+  });
+
+  beforeEach(function() {
+    cwd = process.cwd();
+  });
+
+  afterEach(function() {
+    process.chdir(cwd);
+  });
+
+  describe('#generate', function() {
+    it('revision key contains first 7 characters of git commit hash', function() {
+      process.chdir('tests/fixtures/repo');
+
+      var subject = new DataGenerator();
+
+      return assert.isFulfilled(subject.generate())
+        .then(function(data) {
+          assert.equal(data.revisionKey, '41d41f0');
+        });
+    });
+
+    it('returns a timestamp', function() {
+      process.chdir('tests/fixtures/repo');
+
+      var subject = new DataGenerator();
+
+      return assert.isFulfilled(subject.generate())
+        .then(function(data) {
+          assert.isNotNull(data.timestamp);
+        });
+    });
+
+    it('rejects if no repository found', function() {
+      process.chdir('tests/fixtures/not-a-repo');
+
+      var subject = new DataGenerator();
+
+      return assert.isRejected(subject.generate())
+        .then(function(error) {
+          assert.equal(error, 'Could not find git repository');
+        });
+    });
+  });
+});


### PR DESCRIPTION
This change adds a new data generator, git-commit, that creates a revision key containing the first 7 characters from the git SHA.  This is helpful in supporting the workflow for folks coming over from v0.4.x of ember-cli-deploy.
