### PR TITLE
[BUGFIX] Remove ' from commit hash if needed

### DIFF
--- a/lib/scm-data-generators/git.js
+++ b/lib/scm-data-generators/git.js
@@ -14,8 +14,8 @@ module.exports = CoreObject.extend({
       simpleGit(_this.path).log(function(err, log) {
         var info = log.latest;
         resolve({
-          sha: info.hash.substring(1),
-          email: info.author_email.substring(0, info.author_email.length - 1),
+          sha: info.hash.replace("'",''),
+          email: info.author_email.replace("'",''),
           name: info.author_name,
           timestamp: new Date(info.date).toISOString(),
           branch: gitRepoInfo().branch,


### PR DESCRIPTION
code added in #30 has a CI related bug that did not manifest until after merge (werd!)

In TTY osx consoles an extra ' is sometimes present in front of the
commit sha and at the end of the user email.
this is not true other times (i.e. on CI)

this should fix temporarily while we investigate more
