### PR TITLE
Getting git-commit to work again with CircleCI

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-deploy-plugin": "^0.2.1",
-    "git-repo-info": "^1.1.2",
+    "git-repo-info": "^1.1.4",
     "minimatch": "^2.0.4",
     "rsvp": "^3.0.18",
     "simple-git": "^1.26.2"


### PR DESCRIPTION
We used to deploy directly from CircleCI and at one point a few months back it stopped working. I'm just now getting a chance to dig into it and attached is a fix that works for us.

I read up on the existing issues such as #33 which handles gracefully downgrading when revision info isn't available. However, I SSH'd into the CircleCI instance and revision information is definitely available. I put together this quick script to verify.

```
var gitRepoInfo = require('git-repo-info');
var path = gitRepoInfo._findRepo();
var info = gitRepoInfo(path);

console.log(info);
```

Running that on the instance worked just fine and I received the `sha`. The only difference seemed to be the version of git-repo-info used by `ember-cli-deploy-revision-data` versus what I used when I ran that script. This pull request simply upgrades the dependency which we've tested against our deploy and it's working great.
