### PR TITLE
Use find instead of filter to find first dist file which matches file…

### DIFF
--- a/lib/data-generators/file-hash.js
+++ b/lib/data-generators/file-hash.js
@@ -19,13 +19,13 @@ module.exports = CoreObject.extend({
     var distFiles   = this._plugin.readConfig('distFiles');
     var fingerprint;
 
-    var filePaths = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
+    var matchingPath = distFiles.find(minimatch.filter(filePattern, { matchBase: true }));
 
-    if (!filePaths.length) {
+    if (!matchingPath) {
       return Promise.reject('`' + filePattern + '` does not exist in distDir `' + distDir + '`');
     }
 
-    var filePath = path.join(distDir, filePaths[0]);
+    var filePath = path.join(distDir, matchingPath);
 
     return readFile(filePath)
       .then(function(contents) {


### PR DESCRIPTION
## What Changed & Why

Changed **filter** method by **find** method for retrieve the first file which matches the **filePattern**. This way we save time since we return as soon as we find an occurrence and space since we don't want to have an array just to pick always the first value. 

IMO, also I think looks more readable now. Thanks!
## Related issues
## PR Checklist
## People
