### PR TITLE
Use public interface for git-repo-info

### DIFF
--- a/lib/data-generators/git-commit.js
+++ b/lib/data-generators/git-commit.js
@@ -4,13 +4,12 @@ var Promise     = require('ember-cli/lib/ext/promise');
 
 module.exports = CoreObject.extend({
   generate: function() {
-    var path = gitRepoInfo._findRepo();
+    var info = gitRepoInfo();
 
-    if (path === null) {
+    if (info === null || info.root === null) {
       return Promise.reject('Could not find git repository');
     }
 
-    var info = gitRepoInfo(path);
     var sha = info.sha.slice(0, 7);
 
     if (!sha) {

--- a/lib/data-generators/git-tag-commit.js
+++ b/lib/data-generators/git-tag-commit.js
@@ -4,13 +4,12 @@ var Promise     = require('ember-cli/lib/ext/promise');
 
 module.exports = CoreObject.extend({
   generate: function() {
-    var path = gitRepoInfo._findRepo();
+    var info = gitRepoInfo();
 
-    if (path === null) {
+    if (info === null || info.root === null) {
       return Promise.reject('Could not find git repository');
     }
 
-    var info = gitRepoInfo(path);
     var tag = info.tag;
     var sha = info.sha.slice(0, 8);
 

--- a/lib/data-generators/version-commit.js
+++ b/lib/data-generators/version-commit.js
@@ -15,13 +15,12 @@ module.exports = CoreObject.extend({
   generate: function() {
     var versionFile = this._plugin.readConfig('versionFile');
 
-    var path = gitRepoInfo._findRepo();
+    var info = gitRepoInfo();
 
-    if (path === null) {
+    if (info === null || info.root === null) {
       return Promise.reject('Could not find git repository');
     }
 
-    var info = gitRepoInfo(path);
     var sha = (info.sha || '').slice(0, 8);
     var plugin = this._plugin;
 


### PR DESCRIPTION
## What Changed & Why

The release of git-repo-info 1.3.0 changed the private function that was being used to obtain git information. The change broke deploys using git-commit, git-tag-commit, and version-commit. 

Failure examples: https://travis-ci.org/kkumler/ember-cli-deploy-revision-data/jobs/168504161
`TypeError: Arguments to path.join must be strings`
## Related issues

https://github.com/rwjblue/git-repo-info/pull/26#issuecomment-254361000
## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]
## People

Mention people who would be interested in the changeset (if any)
