### PR TITLE
lock git-repo-info to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chalk": "^1.1.3",
     "core-object": "^2.0.6",
     "ember-cli-deploy-plugin": "^0.2.6",
-    "git-repo-info": "^1.1.4",
+    "git-repo-info": "1.2.0",
     "minimatch": "^3.0.3",
     "rsvp": "^3.2.1",
     "simple-git": "^1.47.0"


### PR DESCRIPTION
## What Changed & Why

see #39 & #40
