### PR TITLE
README: Fix link to plugin documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,6 @@ The following properties are expected to be present on the deployment `context` 
 
 - `npm test`
 
-[1]: http://ember-cli.github.io/ember-cli-deploy/plugins "Plugin Documentation"
+[1]: http://ember-cli-deploy.com/ "Plugin Documentation"
 [2]: https://github.com/ember-cli-deploy/ember-cli-deploy-build "ember-cli-deploy-build"
 [3]: https://github.com/ember-cli/ember-cli-deploy "ember-cli-deploy"


### PR DESCRIPTION
## What Changed & Why

Changed the link to Plugin documentation. The previous link is dead.
