### PR TITLE
pin simple-git to version 1.57.0 as fails with 1.59.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "git-repo-info": "1.2.0",
     "minimatch": "^3.0.3",
     "rsvp": "^3.2.1",
-    "simple-git": "^1.47.0"
+    "simple-git": "1.57.0"
   }
 }


### PR DESCRIPTION
## What Changed & Why
Reference simple-git 1.57.0 instead of ^1.47.0 as deploy fails with simple-git 1.59.0

## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/issues/43
https://github.com/ember-cli-deploy/ember-cli-deploy/issues/432

