### PR TITLE
Pass path string to SCM instead of object

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,8 @@ module.exports = {
       _getScmData: function() {
         var ScmDataGenerator = this.readConfig('scm');
         if (ScmDataGenerator) {
-          return new ScmDataGenerator({
-            plugin: this
-          }).generate();
+          var path = this.readConfig('distDir');
+          return new ScmDataGenerator(path).generate();
         } else {
           return Promise.resolve();
         }


### PR DESCRIPTION
## What Changed & Why

This passes the `distDir` string into `ScmDataGenerator` init instead of an object. This resolves the bug noted in #43 with a permanent fix (rather than the temporary fix suggested by #44).

## Related issues

#43 

## People
@ludalex
@MarkMT
@josephroffey
