### PR TITLE
Fix simple-git version to 1.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "git-repo-info": "^1.3.0",
     "minimatch": "^3.0.3",
     "rsvp": "^3.2.1",
-    "simple-git": "^1.57.0"
+    "simple-git": "1.57.0"
   }
 }


### PR DESCRIPTION
## What Changed & Why
Lock down the simple-git version to 1.57.0 to fix a deployment issue that appears when the latest version (1.64.0) is used.

## Related issues
Closes https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/issues/47

## PR Checklist
- [ ] Test: 
  - Run a deploy with simple-git 1.64.0 to reproduce
  - Check out this branch, `npm install`, and re-run the deploy

## People


