### PR TITLE
Allow configuration of the separator character (`+`) in git-tag-commit and version-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,19 @@ Constructs a revision key based on the most recent git tag and the currently che
 
 ##### revisionKey
 
-The unique identifier of this build based on the git tag, followed by a `+` symbol, followed by the first 8 characters of the current commit hash.
+The unique identifier of this build based on the git tag, followed by a the separator symbol (`+` by default), followed by the first 8 characters of the current commit hash.
 
 For example, if your most recent git tag is `v2.0.3`, and the current commit is `0993043d49f9e0[...]`, this generator will return a revision of `v2.0.3+0993043d`.
 
 ##### timestamp
 
 The timestamp of the current deploy
+
+#### Configuration Options
+
+##### separator
+
+The text used to separate the tag name from the commit sha. By default, `+` is used.
 
 ### Git Commit generator
 
@@ -152,7 +158,7 @@ Similar to the Git Tag Commit generator but uses the `package.json` version stri
 
 ##### revisionKey
 
-The unique identifier of this build based on the version in the `package.json`, followed by a `+` symbol, followed by the first 8 characters of the current commit hash.
+The unique identifier of this build based on the version in the `package.json`, followed by a the separator symbol (`+` by default), followed by the first 8 characters of the current commit hash.
 
 For example, if your package.json version is `v2.0.3`, and the current commit is `0993043d49f9e0[...]`, this generator will return a revision of `v2.0.3+0993043d`.
 
@@ -163,6 +169,10 @@ For example, if your package.json version is `v2.0.3`, and the current commit is
 The timestamp of the current deploy
 
 #### Configuration Options
+
+##### separator
+
+The text used to separate the tag name from the commit sha. By default, `+` is used.
 
 ##### versionFile
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
       name: options.name,
       defaultConfig: {
         type: 'file-hash',
+        separator: '+',
         filePattern: 'index.html',
         versionFile: 'package.json',
         distDir: function(context) {

--- a/lib/data-generators/git-tag-commit.js
+++ b/lib/data-generators/git-tag-commit.js
@@ -3,7 +3,13 @@ var gitRepoInfo = require('git-repo-info');
 var Promise     = require('ember-cli/lib/ext/promise');
 
 module.exports = CoreObject.extend({
+  init: function(options) {
+    this._super();
+    this._plugin = options.plugin;
+  },
+
   generate: function() {
+    var separator = this._plugin.readConfig('separator');
     var info = gitRepoInfo();
 
     if (info === null || info.root === null) {
@@ -18,7 +24,7 @@ module.exports = CoreObject.extend({
     }
 
     return Promise.resolve({
-      revisionKey: info.tag + '+' + sha,
+      revisionKey: info.tag + separator + sha,
       timestamp: new Date().toISOString()
     });
   }

--- a/lib/data-generators/version-commit.js
+++ b/lib/data-generators/version-commit.js
@@ -13,6 +13,7 @@ module.exports = CoreObject.extend({
   },
 
   generate: function() {
+    var separator = this._plugin.readConfig('separator');
     var versionFile = this._plugin.readConfig('versionFile');
 
     var info = gitRepoInfo();
@@ -34,7 +35,7 @@ module.exports = CoreObject.extend({
 
         var versionString = json.version;
         if (sha) {
-          versionString = versionString + '+' + sha;
+          versionString = versionString + separator + sha;
         } else {
           plugin.log('Missing git commit sha, using package version as revisionKey', { color: 'yellow', verbose: true });
         }

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -78,7 +78,7 @@ describe('the index', function() {
         return previous;
       }, []);
 
-      assert.equal(messages.length, 6);
+      assert.equal(messages.length, 7);
     });
 
     it('adds default config to the config object', function() {

--- a/tests/unit/lib/data-generators/git-tag-commit-nodetest.js
+++ b/tests/unit/lib/data-generators/git-tag-commit-nodetest.js
@@ -7,6 +7,13 @@ describe('the git-tag-commit data generator', function() {
   var DataGenerator;
   var cwd;
 
+  var plugin = {
+    stubConfig: {
+      separator: '+'
+    },
+    readConfig: function(key) { return this.stubConfig[key]; },
+  };
+
   before(function() {
     DataGenerator = require('../../../../lib/data-generators/git-tag-commit');
     gitRepoInfo._changeGitDir('dotgit');
@@ -24,7 +31,7 @@ describe('the git-tag-commit data generator', function() {
     it('concatenates the git tag and the git commit hash', function() {
       process.chdir('tests/fixtures/repo');
 
-      var subject = new DataGenerator();
+      var subject = new DataGenerator({ plugin: plugin });
 
       return assert.isFulfilled(subject.generate())
         .then(function(data) {
@@ -32,21 +39,28 @@ describe('the git-tag-commit data generator', function() {
         });
     });
 
-    it('returns a timestamp', function() {
+    it('concatenates the git tag and the git commit hash with a custom separator', function() {
       process.chdir('tests/fixtures/repo');
 
-      var subject = new DataGenerator();
+      var plugin = {
+        stubConfig: {
+          separator: '--'
+        },
+        readConfig: function(key) { return this.stubConfig[key]; },
+      };
+
+      var subject = new DataGenerator({ plugin: plugin });
 
       return assert.isFulfilled(subject.generate())
         .then(function(data) {
-          assert.isNotNull(data.timestamp);
+          assert.equal(data.revisionKey, '2.3.4--41d41f08');
         });
     });
 
     it('rejects if no repository found', function() {
       process.chdir('tests/fixtures/not-a-repo');
 
-      var subject = new DataGenerator();
+      var subject = new DataGenerator({ plugin: plugin });
 
       return assert.isRejected(subject.generate())
         .then(function(error) {
@@ -57,7 +71,7 @@ describe('the git-tag-commit data generator', function() {
     it('rejects if no git tag found', function() {
       process.chdir('tests/fixtures/tagless-repo');
 
-      var subject = new DataGenerator();
+      var subject = new DataGenerator({ plugin: plugin });
 
       return assert.isRejected(subject.generate())
         .then(function(error) {

--- a/tests/unit/lib/data-generators/version-commit-nodetest.js
+++ b/tests/unit/lib/data-generators/version-commit-nodetest.js
@@ -35,7 +35,8 @@ describe('the version-commit data generator', function() {
 
         var plugin = {
           stubConfig: {
-            versionFile: 'package.json'
+            versionFile: 'package.json',
+            separator: '+'
           },
           readConfig: function(key) { return this.stubConfig[key]; },
           log: function() {}
@@ -58,7 +59,8 @@ describe('the version-commit data generator', function() {
         var expectedMessage = /missing git commit sha/i;
         var plugin = {
           stubConfig: {
-            versionFile: 'package.json'
+            versionFile: 'package.json',
+            separator: '+'
           },
           readConfig: function(key) { return this.stubConfig[key]; },
           log: function(message) {
@@ -79,7 +81,8 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
-          versionFile: 'package.json'
+          versionFile: 'package.json',
+          separator: '+'
         },
         readConfig: function(key) { return this.stubConfig[key]; }
       };
@@ -94,12 +97,34 @@ describe('the version-commit data generator', function() {
         });
     });
 
+    it('concatenates the package version and the git commit hash with a custom separator', function() {
+      process.chdir('tests/fixtures/repo');
+
+      var plugin = {
+        stubConfig: {
+          versionFile: 'package.json',
+          separator: '--'
+        },
+        readConfig: function(key) { return this.stubConfig[key]; }
+      };
+
+      var subject = new DataGenerator({
+        plugin: plugin
+      });
+
+      return assert.isFulfilled(subject.generate())
+        .then(function(data) {
+          assert.equal(data.revisionKey, '3.2.1--41d41f08');
+        });
+    });
+
     it('has version source file option', function() {
       process.chdir('tests/fixtures/repo');
 
       var plugin = {
         stubConfig: {
-          versionFile: 'version.json'
+          versionFile: 'version.json',
+          separator: '+'
         },
         readConfig: function(key) { return this.stubConfig[key]; }
       };
@@ -119,7 +144,8 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
-          versionFile: 'package.json'
+          versionFile: 'package.json',
+          separator: '+'
         },
         readConfig: function(key) { return this.stubConfig[key]; }
       };
@@ -139,7 +165,8 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
-          versionFile: 'package.json'
+          versionFile: 'package.json',
+          separator: '+'
         },
         readConfig: function(key) { return this.stubConfig[key]; }
       };
@@ -159,7 +186,8 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
-          versionFile: 'tests/fixtures/missing-version.json'
+          versionFile: 'tests/fixtures/missing-version.json',
+          separator: '+'
         },
         readConfig: function(key) { return this.stubConfig[key]; }
       };


### PR DESCRIPTION
## What Changed & Why

This allows for the `+` symbol in the git-tag-commit and version-commit strategies to be configured by the user.

Why? The error reporting service I'm using at work (Sentry) recently changed the validation for what they consider valid release identifiers and the new format disallows `+`. 

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]
