### PR TITLE
Replace deprecated `ember-cli/ext/promise` with `rsvp`

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -13,11 +13,11 @@
 
 var EOL       = require('os').EOL;
 var multiline = require('multiline');
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP      = require('rsvp');
 var GitHubApi = require('github');
 
 var github         = new GitHubApi({version: '3.0.0'});
-var compareCommits = Promise.denodeify(github.repos.compareCommits);
+var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 var currentVersion = 'v' + require('../package').version;
 
 var user = 'ember-cli-deploy';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 
@@ -38,7 +38,7 @@ module.exports = {
             scm: this._getScmData()
         };
 
-        return Promise.hash(promises)
+        return RSVP.hash(promises)
           .then(function(results) {
             var data = results.data;
             data.scm = results.scm;
@@ -66,13 +66,13 @@ module.exports = {
           var path = this.readConfig('distDir');
           return new ScmDataGenerator(path).generate();
         } else {
-          return Promise.resolve();
+          return RSVP.resolve();
         }
       },
 
       _errorMessage: function(error) {
         this.log(error, { color: 'red' });
-        return Promise.reject(error);
+        return RSVP.reject(error);
       }
     });
     return new DeployPlugin();

--- a/lib/data-generators/file-hash.js
+++ b/lib/data-generators/file-hash.js
@@ -3,7 +3,7 @@ var fs          = require('fs');
 var path        = require('path');
 var minimatch   = require('minimatch');
 var crypto      = require('crypto');
-var Promise     = require('ember-cli/lib/ext/promise');
+var RSVP        = require('rsvp');
 
 var denodeify   = require('rsvp').denodeify;
 var readFile    = denodeify(fs.readFile);
@@ -23,7 +23,7 @@ module.exports = CoreObject.extend({
     var filePaths = distFiles.filter(minimatch.filter(filePattern, { matchBase: true }));
 
     if (!filePaths.length) {
-      return Promise.reject('`' + filePattern + '` does not exist in distDir `' + distDir + '`');
+      return RSVP.reject('`' + filePattern + '` does not exist in distDir `' + distDir + '`');
     }
 
     var filePath = path.join(distDir, filePaths[0]);

--- a/lib/data-generators/git-commit.js
+++ b/lib/data-generators/git-commit.js
@@ -1,22 +1,22 @@
 var CoreObject  = require('core-object');
 var gitRepoInfo = require('git-repo-info');
-var Promise     = require('ember-cli/lib/ext/promise');
+var RSVP        = require('rsvp');
 
 module.exports = CoreObject.extend({
   generate: function() {
     var info = gitRepoInfo();
 
     if (info === null || info.root === null) {
-      return Promise.reject('Could not find git repository');
+      return RSVP.reject('Could not find git repository');
     }
 
     var sha = info.sha.slice(0, 7);
 
     if (!sha) {
-      return Promise.reject('Could not build revision with commit hash `' + sha + '`');
+      return RSVP.reject('Could not build revision with commit hash `' + sha + '`');
     }
 
-    return Promise.resolve({
+    return RSVP.resolve({
       revisionKey: sha,
       timestamp: new Date().toISOString()
     });

--- a/lib/data-generators/git-tag-commit.js
+++ b/lib/data-generators/git-tag-commit.js
@@ -1,6 +1,6 @@
 var CoreObject  = require('core-object');
 var gitRepoInfo = require('git-repo-info');
-var Promise     = require('ember-cli/lib/ext/promise');
+var RSVP        = require('rsvp');
 
 module.exports = CoreObject.extend({
   init: function(options) {
@@ -13,17 +13,17 @@ module.exports = CoreObject.extend({
     var info = gitRepoInfo();
 
     if (info === null || info.root === null) {
-      return Promise.reject('Could not find git repository');
+      return RSVP.reject('Could not find git repository');
     }
 
     var tag = info.tag;
     var sha = info.sha.slice(0, 8);
 
     if (!info.tag || !sha) {
-      return Promise.reject('Could not build revision with tag `' + tag + '` and commit hash `' + sha + '`');
+      return RSVP.reject('Could not build revision with tag `' + tag + '` and commit hash `' + sha + '`');
     }
 
-    return Promise.resolve({
+    return RSVP.resolve({
       revisionKey: info.tag + separator + sha,
       timestamp: new Date().toISOString()
     });

--- a/lib/data-generators/version-commit.js
+++ b/lib/data-generators/version-commit.js
@@ -1,7 +1,7 @@
 var CoreObject  = require('core-object');
 var gitRepoInfo = require('git-repo-info');
 var fs          = require('fs');
-var Promise     = require('ember-cli/lib/ext/promise');
+var RSVP        = require('rsvp');
 
 var denodeify   = require('rsvp').denodeify;
 var readFile    = denodeify(fs.readFile);
@@ -19,7 +19,7 @@ module.exports = CoreObject.extend({
     var info = gitRepoInfo();
 
     if (info === null || info.root === null) {
-      return Promise.reject('Could not find git repository');
+      return RSVP.reject('Could not find git repository');
     }
 
     var sha = (info.sha || '').slice(0, 8);
@@ -30,7 +30,7 @@ module.exports = CoreObject.extend({
         var json = JSON.parse(contents);
 
         if (!json.version) {
-          return Promise.reject('Could not build revision with version `' + json.version + '` and commit hash `' + sha + '`');
+          return RSVP.reject('Could not build revision with version `' + json.version + '` and commit hash `' + sha + '`');
         }
 
         var versionString = json.version;

--- a/lib/scm-data-generators/git.js
+++ b/lib/scm-data-generators/git.js
@@ -1,7 +1,7 @@
 var CoreObject  = require('core-object');
-var Promise     = require('ember-cli/lib/ext/promise');
+var RSVP        = require('rsvp');
 var gitRepoInfo = require('git-repo-info');
-var simpleGit = require('simple-git');
+var simpleGit   = require('simple-git');
 
 module.exports = CoreObject.extend({
   init: function(path) {
@@ -11,7 +11,7 @@ module.exports = CoreObject.extend({
 
   generate: function() {
     var _this = this;
-    return new Promise(function(resolve, reject) {
+    return new RSVP.Promise(function(resolve, reject) {
       simpleGit(_this.path).log(function(err, log) {
         var info = log.latest;
         resolve({


### PR DESCRIPTION
## What Changed & Why
Replaced deprecated ember-cli/ext/promise with rsvp. Ember CLI 2.12 Beta complains about this deprecation.