### PR TITLE
Support custom generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For detailed information on how configuration of plugins works, please refer to 
 ```
 ENV["revision-data"] = {
   type: 'file-hash',
+  generator: null,
   scm: function(context) {
     return require('./lib/scm-data-generators')['git'];
   }
@@ -63,6 +64,21 @@ The type of [Data Generator](#data-generators) to be used.
 
 *Default:* `'file-hash'`
 *Alternatives:* `'git-tag-commit'`, `'git-commit'`, `'version-commit'`
+
+### generator
+
+Custom generator that can be used to override results from selected [Data Generator](#data-generators).
+
+*Default:* `null`
+*Alternative:*
+```js
+function (data) {
+  return Object.assign({}, data, { revisionKey: 'custom-generated-key' });
+}
+```
+
+Parameter `data` contains result of executing selected Data Generator.
+
 
 ### scm
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
       name: options.name,
       defaultConfig: {
         type: 'file-hash',
+        generator: null,
         separator: '+',
         filePattern: 'index.html',
         versionFile: 'package.json',
@@ -31,6 +32,7 @@ module.exports = {
 
       prepare: function(/*context*/) {
         var self = this;
+        var customGenerator = this.pluginConfig['generator'];
 
         var promises = {
             data: this._getData(),
@@ -41,6 +43,11 @@ module.exports = {
           .then(function(results) {
             var data = results.data;
             data.scm = results.scm;
+
+            if (customGenerator && typeof customGenerator === 'function') {
+              data = customGenerator(data);
+            }
+
             self.log('generated revision data for revision: `' + data.revisionKey + '`', { verbose: true });
             return data;
           })
@@ -54,6 +61,7 @@ module.exports = {
         var type = this.readConfig('type');
         this.log('creating revision data using `' + type + '`', { verbose: true });
         var DataGenerator = require('./lib/data-generators')[type];
+
         return new DataGenerator({
           plugin: this
         }).generate();

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -78,7 +78,7 @@ describe('the index', function() {
         return previous;
       }, []);
 
-      assert.equal(messages.length, 7);
+      assert.equal(messages.length, 8);
     });
 
     it('adds default config to the config object', function() {

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -54,6 +54,7 @@ describe('the index', function() {
       plugin.configure(context);
       assert.ok(true); // it didn't throw
     });
+
     it('warns about missing optional config', function() {
       var plugin = subject.createDeployPlugin({
         name: 'revision-data'
@@ -100,6 +101,7 @@ describe('the index', function() {
       assert.isDefined(context.config['revision-data'].type);
       assert.isDefined(context.config['revision-data'].filePattern);
       assert.isDefined(context.config['revision-data'].scm);
+      assert.isDefined(context.config['revision-data'].generator);
     });
   });
 
@@ -136,6 +138,44 @@ describe('the index', function() {
           assert.equal(result.revisionData.revisionKey, 'ae1569f72495012cd5e8588e0f2f5d49');
           assert.isNotNull(result.revisionData.timestamp);
           assert.isNotNull(result.revisionData.scm.email);
+        });
+    });
+
+    it('return the revisionData using custom generator', function() {
+      var plugin = subject.createDeployPlugin({
+        name: 'revision-data'
+      });
+
+      var context = {
+        distDir: 'tests/fixtures',
+        distFiles: ['index.html'],
+        ui: mockUi,
+        config: {
+          "revision-data": {
+            type: 'file-hash',
+            generator: function(data) {
+              assert.equal(data.revisionKey, 'ae1569f72495012cd5e8588e0f2f5d49');
+              return Object.assign({}, data, { revisionKey: 'custom-key'});
+            },
+            filePattern: 'index.html',
+            scm: function(/* context */) {
+              return require('../../lib/scm-data-generators')['git'];
+            },
+            distDir: function(context) {
+              return context.distDir;
+            },
+            distFiles: function(context) {
+              return context.distFiles;
+            }
+          },
+        }
+      };
+
+      plugin.beforeHook(context);
+
+      return assert.isFulfilled(plugin.prepare(context))
+        .then(function(result) {
+          assert.equal(result.revisionData.revisionKey, 'custom-key');
         });
     });
   });


### PR DESCRIPTION
## What Changed & Why
This PR resolves #23, by adding ability to use custom generators on top of choosen one. User is able to override outcome of the selected generator or write completely unique one if needed.

## Related issues
#23 

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
@Bockit
@jrowlingson
@lukemelia