### PR TITLE
Allow to specify revision key through ENV

### DIFF
--- a/lib/data-generators/env.js
+++ b/lib/data-generators/env.js
@@ -1,0 +1,17 @@
+var CoreObject  = require('core-object');
+var RSVP        = require('rsvp');
+
+module.exports = CoreObject.extend({
+  generate: function() {
+    var key = process.env.REVISION_KEY;
+
+    if (!key) {
+      return RSVP.reject('Could not build revision with REVISION_KEY `' + key + '`');
+    }
+
+    return RSVP.resolve({
+      revisionKey: key,
+      timestamp: new Date().toISOString()
+    });
+  }
+});

--- a/lib/data-generators/index.js
+++ b/lib/data-generators/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "env": require('./env'),
   "file-hash": require('./file-hash'),
   "git-tag-commit": require('./git-tag-commit'),
   "git-commit": require('./git-commit'),


### PR DESCRIPTION
## What Changed & Why

We use external deployment system (capistrano), which creates a release with `git archive`, so SCM data is not available. However, it provides revision identifier which can be passed to `ember deploy`. I'd say it would be useful to be able to just pass revision key through ENV in general. I'm wiling to add tests/documentation if this is seen as useful change. Thanks

## PR Checklist

- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]
