### PR TITLE
Allow custom commit hash length when constructing revisionKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Constructs a revision key based on the most recent git tag and the currently che
 
 ##### revisionKey
 
-The unique identifier of this build based on the git tag, followed by a the separator symbol (`+` by default), followed by the first 8 characters of the current commit hash.
+The unique identifier of this build based on the git tag, followed by the separator symbol (`+` by default), followed by the first 8 characters of the current commit hash.
 
 For example, if your most recent git tag is `v2.0.3`, and the current commit is `0993043d49f9e0[...]`, this generator will return a revision of `v2.0.3+0993043d`.
 
@@ -129,6 +129,10 @@ For example, if your most recent git tag is `v2.0.3`, and the current commit is 
 The timestamp of the current deploy
 
 #### Configuration Options
+
+##### commitHashLength
+
+The length of the commit hash that is used when constructing the `revisionKey`.
 
 ##### separator
 
@@ -150,6 +154,12 @@ For example, if the current commit is `0993043d49f9e0[...]`, this generator will
 
 The timestamp of the current deploy
 
+#### Configuration Options
+
+##### commitHashLength
+
+The length of the commit hash that is used as the `revisionKey`.
+
 ### Version Commit generator
 
 Similar to the Git Tag Commit generator but uses the `package.json` version string to construct the revision key instead of the git tag.
@@ -169,6 +179,10 @@ For example, if your package.json version is `v2.0.3`, and the current commit is
 The timestamp of the current deploy
 
 #### Configuration Options
+
+##### commitHashLength
+
+The length of the commit hash that is used when constructing the `revisionKey`.
 
 ##### separator
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,15 @@ module.exports = {
         separator: '+',
         filePattern: 'index.html',
         versionFile: 'package.json',
+
+        commitHashLength: function() {
+          if (this.type === 'git-commit') {
+            return 7;
+          } else {
+            return 8;
+          }
+        },
+
         distDir: function(context) {
           return context.distDir;
         },
@@ -26,7 +35,6 @@ module.exports = {
         scm: function(/* context */) {
           return require('./lib/scm-data-generators')['git'];
         }
-
       },
 
       prepare: function(/*context*/) {

--- a/lib/data-generators/git-commit.js
+++ b/lib/data-generators/git-commit.js
@@ -3,14 +3,20 @@ var gitRepoInfo = require('git-repo-info');
 var RSVP        = require('rsvp');
 
 module.exports = CoreObject.extend({
+  init: function(options) {
+    this._super();
+    this._plugin = options.plugin;
+  },
+
   generate: function() {
+    var commitHashLength = this._plugin.readConfig('commitHashLength');
     var info = gitRepoInfo();
 
     if (info === null || info.root === null) {
       return RSVP.reject('Could not find git repository');
     }
 
-    var sha = info.sha.slice(0, 7);
+    var sha = info.sha.slice(0, commitHashLength);
 
     if (!sha) {
       return RSVP.reject('Could not build revision with commit hash `' + sha + '`');

--- a/lib/data-generators/git-tag-commit.js
+++ b/lib/data-generators/git-tag-commit.js
@@ -9,6 +9,7 @@ module.exports = CoreObject.extend({
   },
 
   generate: function() {
+    var commitHashLength = this._plugin.readConfig('commitHashLength');
     var separator = this._plugin.readConfig('separator');
     var info = gitRepoInfo();
 
@@ -17,7 +18,7 @@ module.exports = CoreObject.extend({
     }
 
     var tag = info.tag;
-    var sha = info.sha.slice(0, 8);
+    var sha = info.sha.slice(0, commitHashLength);
 
     if (!info.tag || !sha) {
       return RSVP.reject('Could not build revision with tag `' + tag + '` and commit hash `' + sha + '`');

--- a/lib/data-generators/version-commit.js
+++ b/lib/data-generators/version-commit.js
@@ -13,6 +13,7 @@ module.exports = CoreObject.extend({
   },
 
   generate: function() {
+    var commitHashLength = this._plugin.readConfig('commitHashLength');
     var separator = this._plugin.readConfig('separator');
     var versionFile = this._plugin.readConfig('versionFile');
 
@@ -22,7 +23,7 @@ module.exports = CoreObject.extend({
       return RSVP.reject('Could not find git repository');
     }
 
-    var sha = (info.sha || '').slice(0, 8);
+    var sha = (info.sha || '').slice(0, commitHashLength);
     var plugin = this._plugin;
 
     return readFile(versionFile)

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -54,6 +54,7 @@ describe('the index', function() {
       plugin.configure(context);
       assert.ok(true); // it didn't throw
     });
+
     it('warns about missing optional config', function() {
       var plugin = subject.createDeployPlugin({
         name: 'revision-data'
@@ -78,7 +79,7 @@ describe('the index', function() {
         return previous;
       }, []);
 
-      assert.equal(messages.length, 7);
+      assert.equal(messages.length, 8);
     });
 
     it('adds default config to the config object', function() {
@@ -100,6 +101,60 @@ describe('the index', function() {
       assert.isDefined(context.config['revision-data'].type);
       assert.isDefined(context.config['revision-data'].filePattern);
       assert.isDefined(context.config['revision-data'].scm);
+    });
+
+    it('defaults commitHashLength to 7 when type is git-commit', function() {
+      var plugin = subject.createDeployPlugin({ name: 'revision-data' });
+
+      var context = {
+        ui: mockUi,
+        config: {
+          'revision-data': {
+            type: 'git-commit'
+          }
+        }
+      };
+
+      plugin.beforeHook(context);
+      plugin.configure(context);
+
+      assert.equal(context.config['revision-data'].commitHashLength(), 7);
+    });
+
+    it('defaults commitHashLength to 8 when type is git-tag-commit', function() {
+      var plugin = subject.createDeployPlugin({ name: 'revision-data' });
+
+      var context = {
+        ui: mockUi,
+        config: {
+          'revision-data': {
+            type: 'git-tag-commit'
+          }
+        }
+      };
+
+      plugin.beforeHook(context);
+      plugin.configure(context);
+
+      assert.equal(context.config['revision-data'].commitHashLength(), 8);
+    });
+
+    it('defaults commitHashLength to 8 when type is version-commit', function() {
+      var plugin = subject.createDeployPlugin({ name: 'revision-data' });
+
+      var context = {
+        ui: mockUi,
+        config: {
+          'revision-data': {
+            type: 'version-commit'
+          }
+        }
+      };
+
+      plugin.beforeHook(context);
+      plugin.configure(context);
+
+      assert.equal(context.config['revision-data'].commitHashLength(), 8);
     });
   });
 

--- a/tests/unit/lib/data-generators/git-commit-test.js
+++ b/tests/unit/lib/data-generators/git-commit-test.js
@@ -7,6 +7,15 @@ describe('the git-commit data generator', function() {
   var DataGenerator;
   var cwd;
 
+  var stubbedPlugin = function(options = {}) {
+    let defaultConfig  = { commitHashLength: 7 };
+
+    return {
+      stubbedConfig: Object.assign(defaultConfig, options),
+      readConfig: function(key) { return this.stubbedConfig[key]; }
+    };
+  };
+
   before(function() {
     DataGenerator = require('../../../../lib/data-generators/git-commit');
     gitRepoInfo._changeGitDir('dotgit');
@@ -21,10 +30,10 @@ describe('the git-commit data generator', function() {
   });
 
   describe('#generate', function() {
-    it('revision key contains first 7 characters of git commit hash', function() {
+    it('sets revision key to first 7 characters of git commit hash', function() {
       process.chdir('tests/fixtures/repo');
 
-      var subject = new DataGenerator();
+      var subject = new DataGenerator({ plugin: stubbedPlugin() });
 
       return assert.isFulfilled(subject.generate())
         .then(function(data) {
@@ -32,10 +41,23 @@ describe('the git-commit data generator', function() {
         });
     });
 
+    it('sets revision key to git commit hash of custom length', function() {
+      process.chdir('tests/fixtures/repo');
+
+      var subject = new DataGenerator({
+        plugin: stubbedPlugin({ commitHashLength: 40 })
+      });
+
+      return assert.isFulfilled(subject.generate())
+        .then(function(data) {
+          assert.equal(data.revisionKey, '41d41f081b45ad50935c08b1203220737d9739b4');
+        });
+    });
+
     it('returns a timestamp', function() {
       process.chdir('tests/fixtures/repo');
 
-      var subject = new DataGenerator();
+      var subject = new DataGenerator({ plugin: stubbedPlugin() });
 
       return assert.isFulfilled(subject.generate())
         .then(function(data) {
@@ -46,7 +68,7 @@ describe('the git-commit data generator', function() {
     it('rejects if no repository found', function() {
       process.chdir('tests/fixtures/not-a-repo');
 
-      var subject = new DataGenerator();
+      var subject = new DataGenerator({ plugin: stubbedPlugin() });
 
       return assert.isRejected(subject.generate())
         .then(function(error) {

--- a/tests/unit/lib/data-generators/git-tag-commit-test.js
+++ b/tests/unit/lib/data-generators/git-tag-commit-test.js
@@ -9,6 +9,7 @@ describe('the git-tag-commit data generator', function() {
 
   var plugin = {
     stubConfig: {
+      commitHashLength: 8,
       separator: '+'
     },
     readConfig: function(key) { return this.stubConfig[key]; },
@@ -39,11 +40,31 @@ describe('the git-tag-commit data generator', function() {
         });
     });
 
+    it('concatenates the git tag and the git commit hash of custom length', function() {
+      process.chdir('tests/fixtures/repo');
+
+      var plugin = {
+        stubConfig: {
+          commitHashLength: 40,
+          separator: '+'
+        },
+        readConfig: function(key) { return this.stubConfig[key]; },
+      };
+
+      var subject = new DataGenerator({ plugin: plugin });
+
+      return assert.isFulfilled(subject.generate())
+        .then(function(data) {
+          assert.equal(data.revisionKey, '2.3.4+41d41f081b45ad50935c08b1203220737d9739b4');
+        });
+    });
+
     it('concatenates the git tag and the git commit hash with a custom separator', function() {
       process.chdir('tests/fixtures/repo');
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           separator: '--'
         },
         readConfig: function(key) { return this.stubConfig[key]; },

--- a/tests/unit/lib/data-generators/version-commit-test.js
+++ b/tests/unit/lib/data-generators/version-commit-test.js
@@ -35,6 +35,7 @@ describe('the version-commit data generator', function() {
 
         var plugin = {
           stubConfig: {
+            commitHashLength: 8,
             versionFile: 'package.json',
             separator: '+'
           },
@@ -58,6 +59,7 @@ describe('the version-commit data generator', function() {
         var expectedMessage = /missing git commit sha/i;
         var plugin = {
           stubConfig: {
+            commitHashLength: 8,
             versionFile: 'package.json',
             separator: '+'
           },
@@ -80,6 +82,7 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           versionFile: 'package.json',
           separator: '+'
         },
@@ -96,11 +99,34 @@ describe('the version-commit data generator', function() {
         });
     });
 
+    it('concatenates the package version and the git commit hash of custom length', function() {
+      process.chdir('tests/fixtures/repo');
+
+      var plugin = {
+        stubConfig: {
+          commitHashLength: 40,
+          versionFile: 'package.json',
+          separator: '+'
+        },
+        readConfig: function(key) { return this.stubConfig[key]; }
+      };
+
+      var subject = new DataGenerator({
+        plugin: plugin
+      });
+
+      return assert.isFulfilled(subject.generate())
+        .then(function(data) {
+          assert.equal(data.revisionKey, '3.2.1+41d41f081b45ad50935c08b1203220737d9739b4');
+        });
+    });
+
     it('concatenates the package version and the git commit hash with a custom separator', function() {
       process.chdir('tests/fixtures/repo');
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           versionFile: 'package.json',
           separator: '--'
         },
@@ -122,6 +148,7 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           versionFile: 'version.json',
           separator: '+'
         },
@@ -143,6 +170,7 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           versionFile: 'package.json',
           separator: '+'
         },
@@ -164,6 +192,7 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           versionFile: 'package.json',
           separator: '+'
         },
@@ -185,6 +214,7 @@ describe('the version-commit data generator', function() {
 
       var plugin = {
         stubConfig: {
+          commitHashLength: 8,
           versionFile: 'tests/fixtures/missing-version.json',
           separator: '+'
         },


### PR DESCRIPTION
## What Changed & Why

This allows the length of the commit hash that is used to construct the `revisionKey` be configured. This applies to the `git-commit`, `git-tag-commit`, and `version-commit` data generator types.

Example usage:

```js
ENV['revision-data'] = {
  type: 'git-commit',
  commitHashLength: 40
}
```

This example would cause the entire commit hash to be used as the `revisionKey`.

## Related issues

Fixes https://github.com/ember-cli-deploy/ember-cli-deploy-revision-data/issues/22

## PR Checklist

- [x] Add tests
- [x] Add documentation
- ~Prefix documentation-only commits with [DOC]~

## People

@bockit